### PR TITLE
[Leveler] fix some issues in regards to textonly and lvl up messages

### DIFF
--- a/leveler/leveler.py
+++ b/leveler/leveler.py
@@ -3328,14 +3328,14 @@ class Leveler(commands.Cog):
 
         if await self.config.guild(server).lvl_msg():  # if lvl msg is enabled
             if await self.config.guild(server).text_only():
-                await self.bot.send_typing(channel)
-                em = discord.Embed(
-                    description="**{} just gained a level{}! (LEVEL {})**".format(
-                        name, server_identifier, new_level
-                    ),
-                    colour=user.colour,
-                )
-                channel.send(embed=em)
+                async with channel.typing():
+                    em = discord.Embed(
+                        description="**{} just gained a level{}! (LEVEL {})**".format(
+                            name, server_identifier, new_level
+                        ),
+                        colour=user.colour,
+                    )
+                    await channel.send(embed=em)
             else:
                 async with channel.typing():
                     levelup = await self.draw_levelup(user, server)


### PR DESCRIPTION
Currently if a server has the text only option set to true the lvl up messages will error due to await self.bot.send_typing(channel), changed this to async with channel.typing() and added an await for sending the embed and verified the messages now work