### PR TITLE
[Leveler] Add settings for MongoDB server

### DIFF
--- a/leveler/__init__.py
+++ b/leveler/__init__.py
@@ -2,4 +2,6 @@ from .leveler import Leveler
 
 
 async def setup(bot):
-    bot.add_cog(Leveler(bot))
+    cog = Leveler(bot)
+    bot.add_cog(cog)
+    await cog.initialize()


### PR DESCRIPTION
This PR includes:
- `client` and `db` moved to cog init.
- Settings commands (`[p]levelerset` group) to choose a different host, port and credentials (username and password) for MongoDB.
- Handling of wrong MongoDB host/port/credentials, instead of just error out it will let bot owner able use settings commands to set a new host/port. Meanwhile all other commands are blocked, but also all functions related to `self.db`.

Opened as a draft since changes will maybe happen.