### PR TITLE
[leveler] overview is not a group command

### DIFF
--- a/leveler/leveler.py
+++ b/leveler/leveler.py
@@ -1192,7 +1192,7 @@ class Leveler(commands.Cog):
         pass
 
     @checks.admin_or_permissions(manage_guild=True)
-    @lvladmin.group()
+    @lvladmin.command()
     async def overview(self, ctx):
         """A list of settings."""
 


### PR DESCRIPTION
`[p]lvladmin overview` has no subcommands but was listed as a `.group()` anyway, resulting in command help being sent whenever the command was invoked.