### PR TITLE
[Leveler] Fix an error when adding roles

### DIFF
--- a/leveler/commands/lvladmin/users.py
+++ b/leveler/commands/lvladmin/users.py
@@ -54,7 +54,7 @@ class Users(MixinMeta):
     @commands.is_owner()
     @lvladmin.command()
     @commands.guild_only()
-    async def setlevel(self, ctx, user: discord.User, level: int):
+    async def setlevel(self, ctx, user: discord.Member, level: int):
         """Set a user's level manually."""
         server = ctx.guild
         channel = ctx.channel


### PR DESCRIPTION
```python
Exception in command 'lvladmin setlevel'
Traceback (most recent call last):
  File "/home/ubuntu/redenv/lib/python3.8/site-packages/discord/ext/commands/core.py", line 85, in wrapped
    ret = await coro(*args, **kwargs)
  File "/home/ubuntu/MikuBot/cogs/CogManager/cogs/leveler/commands/lvladmin/users.py", line 97, in setlevel
    await self._handle_levelup(user, userinfo, server, channel)
  File "/home/ubuntu/MikuBot/cogs/CogManager/cogs/leveler/exp.py", line 139, in _handle_levelup
    await user.add_roles(add_role, reason="Levelup")
AttributeError: 'User' object has no attribute 'add_roles'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/ubuntu/redenv/lib/python3.8/site-packages/discord/ext/commands/bot.py", line 903, in invoke
    await ctx.command.invoke(ctx)
  File "/home/ubuntu/redenv/lib/python3.8/site-packages/redbot/core/commands/commands.py", line 825, in invoke
    await super().invoke(ctx)
  File "/home/ubuntu/redenv/lib/python3.8/site-packages/discord/ext/commands/core.py", line 1329, in invoke
    await ctx.invoked_subcommand.invoke(ctx)
  File "/home/ubuntu/redenv/lib/python3.8/site-packages/discord/ext/commands/core.py", line 859, in invoke
    await injected(*ctx.args, **ctx.kwargs)
  File "/home/ubuntu/redenv/lib/python3.8/site-packages/discord/ext/commands/core.py", line 94, in wrapped
    raise CommandInvokeError(exc) from exc
discord.ext.commands.errors.CommandInvokeError: Command raised an exception: AttributeError: 'User' object has no attribute 'add_roles'```