### PR TITLE
Allow levelup messages to appear in any channel

### DIFF
--- a/leveler/exp.py
+++ b/leveler/exp.py
@@ -114,8 +114,7 @@ class XP(MixinMeta):
 
     async def _handle_levelup(self, user, userinfo, server, channel):
         # channel lock implementation
-        lock_channel = await self.config.guild(server).lvl_msg_lock()
-        if lock_channel:
+        if lock_channel := await self.config.guild(server).lvl_msg_lock():
             channel = server.get_channel(lock_channel)
 
         server_identifier = ""  # super hacky

--- a/leveler/exp.py
+++ b/leveler/exp.py
@@ -114,7 +114,9 @@ class XP(MixinMeta):
 
     async def _handle_levelup(self, user, userinfo, server, channel):
         # channel lock implementation
-        channel = server.get_channel(await self.config.guild(server).lvl_msg_lock())
+        lock_channel = await self.config.guild(server).lvl_msg_lock()
+        if lock_channel:
+            channel = server.get_channel(lock_channel)
 
         server_identifier = ""  # super hacky
         name = user.mention  # also super hacky


### PR DESCRIPTION
Currently you have to set a lock channel before level up messages appear.