### PR TITLE
[Leveler] Humanized ints on images to prevent text overflow

### DIFF
--- a/leveler/def_imgen_utils.py
+++ b/leveler/def_imgen_utils.py
@@ -3,6 +3,7 @@ import random
 import traceback
 import warnings
 from io import BytesIO
+from math import floor, log
 
 from redbot.core.errors import CogLoadError
 
@@ -85,18 +86,20 @@ class DefaultImageGeneratorsUtils(MixinMeta):
         return colors  # returns array
 
     # changes large numbers into smaller strings, ie "10000" becomes 10k
+    # https://github.com/gabzin/django-ytdownloader/blob/e59e728aeac459b73fd4fb9ca663560855af19fd/YouTubeDownloader/views.py#L25
     def _humanize_number(self, number):
         if not number:
             return 0
+        negative = "-" if number < 0 else ""
+        if number < 0:
+            number *= -1
 
-        number = float(f"{number:.3g}")
-        magnitude = 0
-
-        while abs(number) >= 1000:
-            magnitude += 1
-            number /= 1000.0
-
-        return f"{number:.0f}{['', 'k', 'm', 'b', 't', 'q'][magnitude]}"
+        units = ["", "K", "M", "B", "T", "Q"]
+        k = 1000.0
+        magnitude = int(floor(log(number, k)))
+        if magnitude >= len(units):
+            return f">999{units[-1]}"
+        return f"{negative}{number / k**magnitude:.0f}{units[magnitude]}"
 
     # finds the the pixel to center the text
     def _center(self, start, end, text, font):

--- a/leveler/def_imgen_utils.py
+++ b/leveler/def_imgen_utils.py
@@ -84,6 +84,20 @@ class DefaultImageGeneratorsUtils(MixinMeta):
         im.close()
         return colors  # returns array
 
+    # changes large numbers into smaller strings, ie "10000" becomes 10k
+    def _humanize_number(self, number):
+        if not number:
+            return 0
+
+        number = float(f"{number:.3g}")
+        magnitude = 0
+
+        while abs(number) >= 1000:
+            magnitude += 1
+            number /= 1000.0
+
+        return f"{number:.0f}{['', 'k', 'm', 'b', 't', 'q'][magnitude]}"
+
     # finds the the pixel to center the text
     def _center(self, start, end, text, font):
         dist = end - start

--- a/leveler/image_generators.py
+++ b/leveler/image_generators.py
@@ -194,7 +194,11 @@ class ImageGenerators(MixinMeta):
         # labels
         v_label_align = 75
         info_text_color = white_color
-        credits_name = credits_name.upper() if label_fnt.getmask(credits_name.upper()).getbbox()[2] <= balance_width else "BALANCE"
+        credits_name = (
+            credits_name.upper()
+            if label_fnt.getmask(credits_name.upper()).getbbox()[2] <= balance_width
+            else "BALANCE"
+        )
 
         draw.text(
             (self._center(100, 200, "  RANK", label_fnt), v_label_align),
@@ -247,9 +251,7 @@ class ImageGenerators(MixinMeta):
             font=large_fnt,
             fill=info_text_color,
         )  # Level
-        credit_txt = (
-            f"{self._humanize_number(bank_credits)}"
-        )
+        credit_txt = f"{self._humanize_number(bank_credits)}"
         draw.text(
             (self._center(260, 360, credit_txt, large_fnt), v_label_align - 30),
             credit_txt,
@@ -381,7 +383,9 @@ class ImageGenerators(MixinMeta):
         white_text = (250, 250, 250, 255)
         dark_text = (35, 35, 35, 230)
         level_up_text = self._contrast(info_color, white_text, dark_text)
-        lvl_text = "LEVEL {}".format(self._humanize_number(userinfo["servers"][str(server.id)]["level"]))
+        lvl_text = "LEVEL {}".format(
+            self._humanize_number(userinfo["servers"][str(server.id)]["level"])
+        )
         draw.text(
             (self._center(60, 170, lvl_text, level_fnt), 23),
             lvl_text,
@@ -590,7 +594,11 @@ class ImageGenerators(MixinMeta):
 
         balance_width = 85
 
-        credits_name = credits_name.upper() if label_fnt.getmask(credits_name.upper()).getbbox()[2] <= balance_width else "BALANCE"
+        credits_name = (
+            credits_name.upper()
+            if label_fnt.getmask(credits_name.upper()).getbbox()[2] <= balance_width
+            else "BALANCE"
+        )
 
         label_align = 362  # vertical
         draw.text(
@@ -662,9 +670,7 @@ class ImageGenerators(MixinMeta):
             fill=exp_font_color,
         )  # Exp Text
 
-        credit_txt = (
-            f"{self._humanize_number(bank_credits)}"
-        )
+        credit_txt = f"{self._humanize_number(bank_credits)}"
         draw.text(
             (self._center(200, 340, credit_txt, large_fnt), label_align - 27),
             credit_txt,

--- a/leveler/image_generators.py
+++ b/leveler/image_generators.py
@@ -247,7 +247,6 @@ class ImageGenerators(MixinMeta):
         )  # Level
         credit_txt = (
             f"{self._humanize_number(bank_credits)}"
-            f"{credits_name if (credits_name := (credits_name)[0]) != '<' else '$'}"
         )
         draw.text(
             (self._center(260, 360, credit_txt, large_fnt), v_label_align - 30),

--- a/leveler/image_generators.py
+++ b/leveler/image_generators.py
@@ -11,6 +11,7 @@ from redbot.core.errors import CogLoadError
 from redbot.core.utils import AsyncIter
 
 from .abc import MixinMeta
+from .utils import Utils
 
 try:
     from PIL import Image, ImageDraw, ImageFont, ImageOps
@@ -192,6 +193,7 @@ class ImageGenerators(MixinMeta):
         # labels
         v_label_align = 75
         info_text_color = white_color
+        credits_name = credits_name.upper() if label_fnt.getmask(credits_name.upper()).getbbox()[2] < 200 else "BALANCE"
         draw.text(
             (self._center(100, 200, "  RANK", label_fnt), v_label_align),
             "  RANK",
@@ -205,8 +207,8 @@ class ImageGenerators(MixinMeta):
             fill=info_text_color,
         )  # Rank
         draw.text(
-            (self._center(260, 360, "BALANCE", label_fnt), v_label_align),
-            "BALANCE",
+            (self._center(260, 360, credits_name, label_fnt), v_label_align),
+            credits_name,
             font=label_fnt,
             fill=info_text_color,
         )  # Rank
@@ -229,14 +231,14 @@ class ImageGenerators(MixinMeta):
         )  # Symbol
 
         # userinfo
-        server_rank = "#{}".format(server_rank)
+        server_rank = "#{}".format(self._humanize_number(server_rank))
         draw.text(
             (self._center(100, 200, server_rank, large_fnt), v_label_align - 30),
             server_rank,
             font=large_fnt,
             fill=info_text_color,
         )  # Rank
-        level_text = "{}".format(userinfo["servers"][str(server.id)]["level"])
+        level_text = "{}".format(self._humanize_number(userinfo["servers"][str(server.id)]["level"]))
         draw.text(
             (self._center(95, 360, level_text, large_fnt), v_label_align - 30),
             level_text,
@@ -244,7 +246,7 @@ class ImageGenerators(MixinMeta):
             fill=info_text_color,
         )  # Level
         credit_txt = (
-            f"{bank_credits}"
+            f"{self._humanize_number(bank_credits)}"
             f"{credits_name if (credits_name := (credits_name)[0]) != '<' else '$'}"
         )
         draw.text(
@@ -253,7 +255,7 @@ class ImageGenerators(MixinMeta):
             font=large_fnt,
             fill=info_text_color,
         )  # Balance
-        exp_text = f"{exp_frac}/{exp_total}"
+        exp_text = f"{self._humanize_number(exp_frac)}/{self._humanize_number(exp_total)}"
         draw.text(
             (self._center(80, 360, exp_text, exp_fnt), 19),
             exp_text,
@@ -576,7 +578,7 @@ class ImageGenerators(MixinMeta):
         )  # box
 
         # rep_text = "{} REP".format(userinfo["rep"])
-        rep_text = "{}".format(userinfo["rep"])
+        rep_text = "{}".format(self._humanize_number(userinfo["rep"]))
         _write_unicode("\N{HEAVY BLACK HEART}", 257, 9, rep_fnt, rep_u_fnt, rep_fill)
         draw.text(
             (self._center(278, 340, rep_text, rep_fnt), 10),
@@ -585,6 +587,7 @@ class ImageGenerators(MixinMeta):
             fill=rep_fill,
         )  # Exp Text
 
+        credits_name = credits_name.upper() if label_fnt.getmask(credits_name.upper()).getbbox()[2] <= label_fnt.getmask("BALANCE").getbbox()[2] else "BALANCE"
         label_align = 362  # vertical
         draw.text(
             (self._center(0, 140, "    RANK", label_fnt), label_align),
@@ -599,8 +602,8 @@ class ImageGenerators(MixinMeta):
             fill=info_text_color,
         )  # Exp
         draw.text(
-            (self._center(200, 340, "BALANCE", label_fnt), label_align),
-            "BALANCE",
+            (self._center(200, 340, credits_name, label_fnt), label_align),
+            credits_name,
             font=label_fnt,
             fill=info_text_color,
         )  # Credits
@@ -620,7 +623,7 @@ class ImageGenerators(MixinMeta):
         )  # Symbol
 
         # userinfo
-        global_rank = "#{}".format(global_rank)
+        global_rank = "#{}".format(self._humanize_number(global_rank))
         global_level = "{}".format(level)
         draw.text(
             (self._center(0, 140, global_rank, large_fnt), label_align - 27),
@@ -647,7 +650,7 @@ class ImageGenerators(MixinMeta):
             [(0, 305), (bar_length, 323)],
             fill=(exp_fill[0], exp_fill[1], exp_fill[2], 255),
         )  # box
-        exp_text = f"{exp_frac}/{next_level_exp}"  # Exp
+        exp_text = f"{self._humanize_number(exp_frac)}/{self._humanize_number(next_level_exp)}"  # Exp
         draw.text(
             (self._center(0, 340, exp_text, exp_fnt), 305),
             exp_text,
@@ -656,8 +659,7 @@ class ImageGenerators(MixinMeta):
         )  # Exp Text
 
         credit_txt = (
-            f"{bank_credits}"
-            f"{credits_name if (credits_name := credits_name[0]) != '<' else '$'}"
+            f"{self._humanize_number(bank_credits)}"
         )
         draw.text(
             (self._center(200, 340, credit_txt, large_fnt), label_align - 27),

--- a/leveler/image_generators.py
+++ b/leveler/image_generators.py
@@ -193,7 +193,7 @@ class ImageGenerators(MixinMeta):
         # labels
         v_label_align = 75
         info_text_color = white_color
-        credits_name = credits_name.upper() if label_fnt.getmask(credits_name.upper()).getbbox()[2] < 200 else "BALANCE"
+        credits_name = credits_name.upper() if label_fnt.getmask(credits_name.upper()).getbbox()[2] <= label_fnt.getmask("BALANCE").getbbox()[2] else "BALANCE"
         draw.text(
             (self._center(100, 200, "  RANK", label_fnt), v_label_align),
             "  RANK",

--- a/leveler/image_generators.py
+++ b/leveler/image_generators.py
@@ -380,7 +380,7 @@ class ImageGenerators(MixinMeta):
         white_text = (250, 250, 250, 255)
         dark_text = (35, 35, 35, 230)
         level_up_text = self._contrast(info_color, white_text, dark_text)
-        lvl_text = "LEVEL {}".format(userinfo["servers"][str(server.id)]["level"])
+        lvl_text = "LEVEL {}".format(self._humanize_number(userinfo["servers"][str(server.id)]["level"]))
         draw.text(
             (self._center(60, 170, lvl_text, level_fnt), 23),
             lvl_text,

--- a/leveler/image_generators.py
+++ b/leveler/image_generators.py
@@ -11,7 +11,6 @@ from redbot.core.errors import CogLoadError
 from redbot.core.utils import AsyncIter
 
 from .abc import MixinMeta
-from .utils import Utils
 
 try:
     from PIL import Image, ImageDraw, ImageFont, ImageOps
@@ -190,10 +189,13 @@ class ImageGenerators(MixinMeta):
             grey_color,
         )  # Name
 
+        balance_width = 63
+
         # labels
         v_label_align = 75
         info_text_color = white_color
-        credits_name = credits_name.upper() if label_fnt.getmask(credits_name.upper()).getbbox()[2] <= label_fnt.getmask("BALANCE").getbbox()[2] else "BALANCE"
+        credits_name = credits_name.upper() if label_fnt.getmask(credits_name.upper()).getbbox()[2] <= balance_width else "BALANCE"
+
         draw.text(
             (self._center(100, 200, "  RANK", label_fnt), v_label_align),
             "  RANK",
@@ -238,7 +240,7 @@ class ImageGenerators(MixinMeta):
             font=large_fnt,
             fill=info_text_color,
         )  # Rank
-        level_text = "{}".format(self._humanize_number(userinfo["servers"][str(server.id)]["level"]))
+        level_text = "{}".format(userinfo["servers"][str(server.id)]["level"])
         draw.text(
             (self._center(95, 360, level_text, large_fnt), v_label_align - 30),
             level_text,
@@ -254,7 +256,7 @@ class ImageGenerators(MixinMeta):
             font=large_fnt,
             fill=info_text_color,
         )  # Balance
-        exp_text = f"{self._humanize_number(exp_frac)}/{self._humanize_number(exp_total)}"
+        exp_text = f"{exp_frac}/{exp_total}"
         draw.text(
             (self._center(80, 360, exp_text, exp_fnt), 19),
             exp_text,
@@ -586,7 +588,10 @@ class ImageGenerators(MixinMeta):
             fill=rep_fill,
         )  # Exp Text
 
-        credits_name = credits_name.upper() if label_fnt.getmask(credits_name.upper()).getbbox()[2] <= label_fnt.getmask("BALANCE").getbbox()[2] else "BALANCE"
+        balance_width = 85
+
+        credits_name = credits_name.upper() if label_fnt.getmask(credits_name.upper()).getbbox()[2] <= balance_width else "BALANCE"
+
         label_align = 362  # vertical
         draw.text(
             (self._center(0, 140, "    RANK", label_fnt), label_align),
@@ -649,7 +654,7 @@ class ImageGenerators(MixinMeta):
             [(0, 305), (bar_length, 323)],
             fill=(exp_fill[0], exp_fill[1], exp_fill[2], 255),
         )  # box
-        exp_text = f"{self._humanize_number(exp_frac)}/{self._humanize_number(next_level_exp)}"  # Exp
+        exp_text = f"{exp_frac}/{next_level_exp}"  # Exp
         draw.text(
             (self._center(0, 340, exp_text, exp_fnt), 305),
             exp_text,

--- a/leveler/utils.py
+++ b/leveler/utils.py
@@ -80,17 +80,3 @@ class Utils(MixinMeta):
         if len(text) > max_length:
             return text[: max_length - 1] + "…"
         return text
-
-    # changes large numbers into smaller strings, ie "10000" becomes 10k
-    def _humanize_number(self, number):
-        if not number:
-            return 0
-
-        number = float(f"{number:.3g}")
-        magnitude = 0
-
-        while abs(number) >= 1000:
-            magnitude += 1
-            number /= 1000.0
-
-        return "{}{}".format("{:f}".format(number).rstrip('0').rstrip('.'), ['', 'k', 'm', 'b', 't'][magnitude])

--- a/leveler/utils.py
+++ b/leveler/utils.py
@@ -80,3 +80,17 @@ class Utils(MixinMeta):
         if len(text) > max_length:
             return text[: max_length - 1] + "…"
         return text
+
+    # changes large numbers into smaller strings, ie "10000" becomes 10k
+    def _humanize_number(self, number):
+        if not number:
+            return 0
+
+        number = float(f"{number:.3g}")
+        magnitude = 0
+
+        while abs(number) >= 1000:
+            magnitude += 1
+            number /= 1000.0
+
+        return "{}{}".format("{:f}".format(number).rstrip('0').rstrip('.'), ['', 'k', 'm', 'b', 't'][magnitude])


### PR DESCRIPTION
Humanized text fields to prevent text overlap/overflow on the borders of images/text. May require further testing on users with higher levels/large economy balances/low ranks on servers with high member counts. 

### Changes:
- Added a new method `def _humanize_number` that accepts an int as an argument and returns a string in a humanized format (i.e., 12600 becomes 12.6k)
- Humanized all integer fields in `def make_levelup_image`, `def make_profile_image`, and `def make_rank_image`
- To accommodate the new letter next to int fields, `currency_name` has been moved from being an acronym next to underneath the text, provided it's short enough (for example, if the guild currency name is "cogs", the label will say "COGS" -- if the guild currency name is "˜”*°•.˜”*°• money •°*”˜.•°*”˜" or some other long-ish name, then the label defaults back to saying "BALANCE"