### PR TITLE
[Captcha] Add `captcha` and `skipcaptcha` commands.

### DIFF
--- a/captcha/api.py
+++ b/captcha/api.py
@@ -9,7 +9,7 @@ from redbot.core.commands import MissingPermissions
 from redbot.core.utils import chat_formatting as form
 from redbot.core.utils.predicates import MessagePredicate, ReactionPredicate
 
-from .errors import AskedForReload, LeftServerError, MissingRequiredValueError
+from .errors import AskedForReload, LeftServerError, MissingRequiredValueError, SkipCaptcha
 
 log = logging.getLogger("red.fixator10-cogs.captcha")
 
@@ -27,6 +27,7 @@ class Challenge:
         self.member: discord.Member = member
         self.guild: discord.Guild = member.guild
         self.config: dict = data  # Will contain the config of the guild.
+        self.skip_captcha = False
 
         if not self.config["channel"]:
             raise MissingRequiredValueError("Missing channel for verification.")
@@ -169,6 +170,8 @@ class Challenge:
             timeout=self.config["timeout"] * 60,
             return_when=asyncio.FIRST_COMPLETED,
         )
+        if self.skip_captcha:
+            raise SkipCaptcha("The captcha has been skipped.")
         self.cancel_tasks()
         if len(done) == 0:
             raise TimeoutError("User didn't answer.")

--- a/captcha/errors.py
+++ b/captcha/errors.py
@@ -29,5 +29,6 @@ class MissingRequiredValueError(Exception):
 class LeftServerError(Exception):
     """An error raised in case the user left the server while challenging."""
 
+
 class SkipCaptcha(Exception):
     """An error raised in case the challenge is skipped by an admin."""

--- a/captcha/errors.py
+++ b/captcha/errors.py
@@ -28,3 +28,6 @@ class MissingRequiredValueError(Exception):
 
 class LeftServerError(Exception):
     """An error raised in case the user left the server while challenging."""
+
+class SkipCaptcha(Exception):
+    """An error raised in case the challenge is skipped by an admin."""

--- a/captcha/events.py
+++ b/captcha/events.py
@@ -5,11 +5,13 @@ import logging
 from abc import ABCMeta
 from traceback import format_exception
 
-from discord import Member
+from discord import Forbidden, Member
 from redbot.core import commands
-from redbot.core.utils.chat_formatting import bold
+from redbot.core.utils.chat_formatting import bold, error
 
 from .abc import MixinMeta
+from .api import Challenge
+from .errors import AlreadyHaveCaptchaError, SkipCaptcha
 
 log = logging.getLogger("red.fixator10-cogs.captcha")
 
@@ -22,6 +24,8 @@ class Listeners(MixinMeta, metaclass=ABCMeta):
             # noinspection PyBroadException
             try:
                 await self.realize_challenge(challenge)
+            except SkipCaptcha:
+                return
             except Exception as e:
                 log.critical(
                     f"An unexpected error happened!\n"
@@ -53,6 +57,67 @@ class Listeners(MixinMeta, metaclass=ABCMeta):
         finally:
             await self.delete_challenge_for(member)
 
+    async def skip_challenge(self, author: Member, challenge: Challenge):
+        try:
+            challenge.skip_captcha = True
+            challenge.cancel_tasks()
+            roles = [
+                challenge.guild.get_role(role)
+                for role in await self.data.guild(challenge.guild).autoroles()
+            ]
+            await self.congratulation(challenge, roles)
+            await self.remove_temprole(challenge)
+
+            await self.send_or_update_log_message(
+                challenge.guild,
+                f"✅ Captcha skipped by {author.mention}.",
+                challenge.messages["logs"],
+                allowed_tries=(challenge.trynum, challenge.limit),
+                member=challenge.member,
+            )
+            await self.send_or_update_log_message(
+                challenge.guild,
+                bold("Roles added, Captcha skipped."),
+                challenge.messages["logs"],
+                member=challenge.member,
+            )
+        except commands.MissingPermissions:
+            try:
+                await challenge.member.send(
+                    f"Please contact the administrator of {challenge.guild.name} in order to obtain "
+                    "access to the server, I was unable to give you the roles on the server."
+                )
+            except Forbidden:
+                await challenge.channel.send(
+                    challenge.member.mention
+                    + ": "
+                    + f"Please contact the administrator of {challenge.guild.name} in order to obtain "
+                    "access to the server, I was unable to give you the roles on the server.",
+                    delete_after=10,
+                )
+            logmsg = challenge.messages["logs"]
+            await self.send_or_update_log_message(
+                challenge.guild,
+                error(bold("Permission missing for giving roles! Member alerted.")),
+                logmsg,
+                member=challenge.member,
+            )
+        finally:
+            try:
+                await challenge.cleanup_messages()
+            except commands.MissingPermissions:
+                await self.send_or_update_log_message(
+                    challenge.guild,
+                    error(
+                        bold(
+                            "Missing permissions for deleting all messages for verification!"
+                        )
+                    ),
+                    challenge.messages.get("logs"),
+                    member=challenge.member,
+                )
+        return True
+
     @commands.Cog.listener()
     async def on_member_join(self, member: Member):
         await self.runner(member)
@@ -60,3 +125,58 @@ class Listeners(MixinMeta, metaclass=ABCMeta):
     @commands.Cog.listener()
     async def on_member_remove(self, member: Member):
         await self.cleaner(member)
+
+    @commands.guildowner()
+    @commands.command()
+    async def captcha(self, ctx, *members: Member):
+        """Start a captcha challenge for the specified members."""
+        await ctx.send("Running Captcha challenges... this may take a while!")
+        async with ctx.typing():
+            time = await self.data.guild(ctx.guild).timeout()
+            await self.data.guild(ctx.guild).timeout.set(20)
+            for member in members:
+                try:
+                    await self.runner(member)
+                except AlreadyHaveCaptchaError:
+                    await ctx.send(
+                        f"The user {member.display_name} ({member.id}) already have a captcha challenge running."
+                    )
+            await self.data.guild(ctx.guild).timeout.set(time)
+        message = (
+            "**The challenge has finished for the following members:**\n(unless the user already had a challenge in progress)\n"
+            + ", ".join(member.display_name for member in members if not member.bot)
+        )
+        if any(member.bot for member in members):
+            message += (
+                "\n\n**The following members were not challenged because they were bots:**\n"
+                + ", ".join(member.display_name for member in members if member.bot)
+            )
+        await ctx.send(message)
+
+    @commands.admin_or_permissions(manage_guild=True)
+    @commands.command(aliases=["bypasscaptcha"])
+    async def skipcaptcha(self, ctx: commands.Context, *members: Member):
+        """Cancel a captcha challenge for the specified members."""
+        await ctx.send("Cancelling Captcha challenges...")
+        async with ctx.typing():
+            cancelled_challenge = []
+            for member in members:
+                try:
+                    challenge = self.obtain_challenge(member)
+                except KeyError:
+                    await ctx.send(
+                        f"The user {member.display_name} ({member.id}) is not challenging any Captcha."
+                    )
+                else:
+                    cancelled_challenge.append(member)
+                    try:
+                        await self.skip_challenge(ctx.author, challenge)
+                    except Exception:
+                        pass
+                    finally:
+                        await self.delete_challenge_for(member)
+        message = (
+            "**The challenge has cancelled for the following members:**\n"
+            + ", ".join(member.display_name for member in members if not member.bot and member in cancelled_challenge)
+        )
+        await ctx.send(message)

--- a/captcha/events.py
+++ b/captcha/events.py
@@ -108,11 +108,7 @@ class Listeners(MixinMeta, metaclass=ABCMeta):
             except commands.MissingPermissions:
                 await self.send_or_update_log_message(
                     challenge.guild,
-                    error(
-                        bold(
-                            "Missing permissions for deleting all messages for verification!"
-                        )
-                    ),
+                    error(bold("Missing permissions for deleting all messages for verification!")),
                     challenge.messages.get("logs"),
                     member=challenge.member,
                 )
@@ -175,8 +171,9 @@ class Listeners(MixinMeta, metaclass=ABCMeta):
                         pass
                     finally:
                         await self.delete_challenge_for(member)
-        message = (
-            "**The challenge has cancelled for the following members:**\n"
-            + ", ".join(member.display_name for member in members if not member.bot and member in cancelled_challenge)
+        message = "**The challenge has cancelled for the following members:**\n" + ", ".join(
+            member.display_name
+            for member in members
+            if not member.bot and member in cancelled_challenge
         )
         await ctx.send(message)

--- a/captcha/events.py
+++ b/captcha/events.py
@@ -165,12 +165,8 @@ class Listeners(MixinMeta, metaclass=ABCMeta):
                     )
                 else:
                     cancelled_challenge.append(member)
-                    try:
-                        await self.skip_challenge(ctx.author, challenge)
-                    except Exception:
-                        pass
-                    finally:
-                        await self.delete_challenge_for(member)
+                    await self.skip_challenge(ctx.author, challenge)
+                    await self.delete_challenge_for(member)
         message = "**The challenge has cancelled for the following members:**\n" + ", ".join(
             member.display_name
             for member in members


### PR DESCRIPTION
Hello,
This PR adds to the cog Captcha a command to manually launch a challenge (if the bot is offline when a user joins the server) and another to cancel an existing challenge.
This PR already existed on the semi-original repo of this cog ([Kreusada-Cogs#197](https://github.com/Kreusada/Kreusada-Cogs/pull/197)), but Kreusada had refused due to lack of time. So I'm doing it again here.
If you wish, the kick could be cancelled for a manually launched challenge, if the user is offline.
The old PR was finally not functional because the tasks were not cancelled correctly. I don't know why my tests were conclusive. Now everything works.
Thanks in advance,
AAA3A