### PR TITLE
[Leveler] Fix dep warnings on PIL 9.2 or greater

### DIFF
--- a/leveler/def_imgen_utils.py
+++ b/leveler/def_imgen_utils.py
@@ -19,6 +19,10 @@ except Exception as e:
         "Installing-Leveler#my-bot-throws-error-on-load-something-related-to-pillow."
     )
 
+try:
+    from PIL.Image.Resampling import LANCZOS
+except ModuleNotFoundError:
+    from PIL.Image import LANCZOS
 
 try:
     import numpy
@@ -150,7 +154,7 @@ class DefaultImageGeneratorsUtils(MixinMeta):
         circle = Image.new("L", (raw_length, raw_length), 0)
         draw = ImageDraw.Draw(circle)
         draw.ellipse((0, 0, raw_length, raw_length), fill=255)
-        circle = circle.resize((rad * 2, rad * 2), Image.ANTIALIAS)
+        circle = circle.resize((rad * 2, rad * 2), LANCZOS)
 
         alpha = Image.new("L", im.size, 255)
         w, h = im.size

--- a/leveler/def_imgen_utils.py
+++ b/leveler/def_imgen_utils.py
@@ -108,7 +108,7 @@ class DefaultImageGeneratorsUtils(MixinMeta):
     # finds the the pixel to center the text
     def _center(self, start, end, text, font):
         dist = end - start
-        width = font.getlength(text)[0]
+        width = int(font.getlength(text))
         start_pos = start + ((dist - width) / 2)
         return int(start_pos)
 

--- a/leveler/def_imgen_utils.py
+++ b/leveler/def_imgen_utils.py
@@ -108,7 +108,7 @@ class DefaultImageGeneratorsUtils(MixinMeta):
     # finds the the pixel to center the text
     def _center(self, start, end, text, font):
         dist = end - start
-        width = font.getsize(text)[0]
+        width = font.getlength(text)[0]
         start_pos = start + ((dist - width) / 2)
         return int(start_pos)
 

--- a/leveler/def_imgen_utils.py
+++ b/leveler/def_imgen_utils.py
@@ -108,7 +108,7 @@ class DefaultImageGeneratorsUtils(MixinMeta):
     # finds the the pixel to center the text
     def _center(self, start, end, text, font):
         dist = end - start
-        width = int(font.getlength(text))
+        width = self._write_getsize_position_character(font, text)
         start_pos = start + ((dist - width) / 2)
         return int(start_pos)
 

--- a/leveler/def_imgen_utils.py
+++ b/leveler/def_imgen_utils.py
@@ -108,7 +108,7 @@ class DefaultImageGeneratorsUtils(MixinMeta):
     # finds the the pixel to center the text
     def _center(self, start, end, text, font):
         dist = end - start
-        width = self._write_getsize_position_character(font, text)
+        width = self._get_character_pixel_width(font, text)
         start_pos = start + ((dist - width) / 2)
         return int(start_pos)
 

--- a/leveler/image_generators.py
+++ b/leveler/image_generators.py
@@ -81,10 +81,10 @@ class ImageGenerators(MixinMeta):
                 # if char.isalnum() or char in string.punctuation or char in string.whitespace:
                 if self.char_in_font(char, check_font):
                     draw.text((write_pos, y), "{}".format(char), font=font, fill=fill)
-                    write_pos += font.getsize(char)[0]
+                    write_pos += font.getlength(char)[0]
                 else:
                     draw.text((write_pos, y), "{}".format(char), font=unicode_font, fill=fill)
-                    write_pos += unicode_font.getsize(char)[0]
+                    write_pos += unicode_font.getlength(char)[0]
             check_font.close()
 
         # set canvas
@@ -454,10 +454,10 @@ class ImageGenerators(MixinMeta):
                 # if char.isalnum() or char in string.punctuation or char in string.whitespace:
                 if self.char_in_font(char, check_font):
                     draw.text((write_pos, y), "{}".format(char), font=font, fill=fill)
-                    write_pos += font.getsize(char)[0]
+                    write_pos += font.getlength(char)[0]
                 else:
                     draw.text((write_pos, y), "{}".format(char), font=unicode_font, fill=fill)
-                    write_pos += unicode_font.getsize(char)[0]
+                    write_pos += unicode_font.getlength(char)[0]
             check_font.close()
 
         # COLORS
@@ -693,7 +693,7 @@ class ImageGenerators(MixinMeta):
             # for line in textwrap.wrap('userinfo["info"]', width=200):
             # draw.text((margin, offset), line, font=text_fnt, fill=white_color)
             _write_unicode(line, margin, offset, text_fnt, text_u_fnt, txt_color)
-            offset += text_fnt.getsize(line)[1] + 2
+            offset += text_fnt.getlength(line)[1] + 2
 
         # if await self.config.badge_type() == "circles":
         # circles require antialiasing

--- a/leveler/image_generators.py
+++ b/leveler/image_generators.py
@@ -22,6 +22,10 @@ except Exception as e:
         "https://github.com/fixator10/Fixator10-Cogs/wiki/"
         "Installing-Leveler#my-bot-throws-error-on-load-something-related-to-pillow."
     )
+try:
+    from PIL.Image.Resampling import LANCZOS
+except ModuleNotFoundError:
+    from PIL.Image import LANCZOS
 
 
 log = getLogger("red.fixator10-cogs.leveler")
@@ -96,7 +100,7 @@ class ImageGenerators(MixinMeta):
         info_section_process = Image.new("RGBA", (bg_width, height), bg_color)
         # puts in background
         temp = bg_image
-        bg_image = bg_image.resize((width, height), Image.ANTIALIAS)
+        bg_image = bg_image.resize((width, height), LANCZOS)
         temp.close()
         temp = bg_image
         bg_image = bg_image.crop((0, 0, width, height))
@@ -151,9 +155,9 @@ class ImageGenerators(MixinMeta):
         draw_lvl_circle.ellipse([0, 0, raw_length, raw_length], fill=(250, 250, 250, 250))
         # put on profile circle background
         temp = lvl_circle
-        lvl_circle = lvl_circle.resize((lvl_circle_dia, lvl_circle_dia), Image.ANTIALIAS)
+        lvl_circle = lvl_circle.resize((lvl_circle_dia, lvl_circle_dia), LANCZOS)
         temp.close()
-        lvl_bar_mask = mask.resize((lvl_circle_dia, lvl_circle_dia), Image.ANTIALIAS)
+        lvl_bar_mask = mask.resize((lvl_circle_dia, lvl_circle_dia), LANCZOS)
         process.paste(lvl_circle, (circle_left, circle_top), lvl_bar_mask)
         lvl_bar_mask.close()
 
@@ -165,13 +169,13 @@ class ImageGenerators(MixinMeta):
         # put in profile picture
         output = ImageOps.fit(profile_image, (raw_length, raw_length), centering=(0.5, 0.5))
         temp = output
-        output.resize((profile_size, profile_size), Image.ANTIALIAS)
+        output.resize((profile_size, profile_size), LANCZOS)
         temp.close()
         temp = mask
-        mask = mask.resize((profile_size, profile_size), Image.ANTIALIAS)
+        mask = mask.resize((profile_size, profile_size), LANCZOS)
         temp.close()
         temp = profile_image
-        profile_image = profile_image.resize((profile_size, profile_size), Image.ANTIALIAS)
+        profile_image = profile_image.resize((profile_size, profile_size), LANCZOS)
         temp.close()
         process.paste(profile_image, (circle_left + border, circle_top + border), mask)
 
@@ -310,7 +314,7 @@ class ImageGenerators(MixinMeta):
 
         # puts in background
         temp = bg_image
-        bg_image = bg_image.resize((width, height), Image.ANTIALIAS)
+        bg_image = bg_image.resize((width, height), LANCZOS)
         temp.close()
         temp = bg_image
         bg_image = bg_image.crop((0, 0, width, height))
@@ -358,9 +362,9 @@ class ImageGenerators(MixinMeta):
         draw_lvl_circle = ImageDraw.Draw(lvl_circle)
         draw_lvl_circle.ellipse([0, 0, raw_length, raw_length], fill=(250, 250, 250, 180))
         temp = lvl_circle
-        lvl_circle = lvl_circle.resize((lvl_circle_dia, lvl_circle_dia), Image.ANTIALIAS)
+        lvl_circle = lvl_circle.resize((lvl_circle_dia, lvl_circle_dia), LANCZOS)
         temp.close()
-        lvl_bar_mask = mask.resize((lvl_circle_dia, lvl_circle_dia), Image.ANTIALIAS)
+        lvl_bar_mask = mask.resize((lvl_circle_dia, lvl_circle_dia), LANCZOS)
         process.paste(lvl_circle, (circle_left, circle_top), lvl_bar_mask)
         lvl_bar_mask.close()
 
@@ -369,13 +373,13 @@ class ImageGenerators(MixinMeta):
         # put in profile picture
         output = ImageOps.fit(profile_image, (raw_length, raw_length), centering=(0.5, 0.5))
         temp = output
-        output.resize((profile_size, profile_size), Image.ANTIALIAS)
+        output.resize((profile_size, profile_size), LANCZOS)
         temp.close()
         temp = mask
-        mask = mask.resize((profile_size, profile_size), Image.ANTIALIAS)
+        mask = mask.resize((profile_size, profile_size), LANCZOS)
         temp.close()
         temp = profile_image
-        profile_image = profile_image.resize((profile_size, profile_size), Image.ANTIALIAS)
+        profile_image = profile_image.resize((profile_size, profile_size), LANCZOS)
         temp.close()
         process.paste(profile_image, (circle_left + border, circle_top + border), mask)
 
@@ -499,7 +503,7 @@ class ImageGenerators(MixinMeta):
 
         # puts in background
         temp = bg_image
-        bg_image = bg_image.resize((340, 340), Image.ANTIALIAS)
+        bg_image = bg_image.resize((340, 340), LANCZOS)
         temp.close()
         temp = bg_image
         bg_image = bg_image.crop((0, 0, 340, 305))
@@ -532,9 +536,9 @@ class ImageGenerators(MixinMeta):
         )
         # put border
         temp = lvl_circle
-        lvl_circle = lvl_circle.resize((lvl_circle_dia, lvl_circle_dia), Image.ANTIALIAS)
+        lvl_circle = lvl_circle.resize((lvl_circle_dia, lvl_circle_dia), LANCZOS)
         temp.close()
-        lvl_bar_mask = mask.resize((lvl_circle_dia, lvl_circle_dia), Image.ANTIALIAS)
+        lvl_bar_mask = mask.resize((lvl_circle_dia, lvl_circle_dia), LANCZOS)
         process.paste(lvl_circle, (circle_left, circle_top), lvl_bar_mask)
         lvl_bar_mask.close()
 
@@ -543,10 +547,10 @@ class ImageGenerators(MixinMeta):
         border = int(total_gap / 2)
         profile_size = lvl_circle_dia - total_gap
         temp = mask
-        mask = mask.resize((profile_size, profile_size), Image.ANTIALIAS)
+        mask = mask.resize((profile_size, profile_size), LANCZOS)
         temp.close()
         temp = profile_image
-        profile_image = profile_image.resize((profile_size, profile_size), Image.ANTIALIAS)
+        profile_image = profile_image.resize((profile_size, profile_size), LANCZOS)
         temp.close()
         process.paste(profile_image, (circle_left + border, circle_top + border), mask)
 
@@ -731,7 +735,7 @@ class ImageGenerators(MixinMeta):
                 badge_image = badge_image_original.convert("RGBA")
                 badges_images[num].close()
                 badge_image_original.close()
-                badge_image_resized = badge_image.resize((raw_length, raw_length), Image.ANTIALIAS)
+                badge_image_resized = badge_image.resize((raw_length, raw_length), LANCZOS)
                 badge_image.close()
 
                 # structured like this because if border = 0, still leaves outline.
@@ -740,9 +744,9 @@ class ImageGenerators(MixinMeta):
                     # put border on ellipse/circle
                     output = ImageOps.fit(square, (raw_length, raw_length), centering=(0.5, 0.5))
                     temp = output
-                    output = output.resize((size, size), Image.ANTIALIAS)
+                    output = output.resize((size, size), LANCZOS)
                     temp.close()
-                    outer_mask = mask.resize((size, size), Image.ANTIALIAS)
+                    outer_mask = mask.resize((size, size), LANCZOS)
                     process.paste(output, coord, outer_mask)
                     outer_mask.close()
 
@@ -753,9 +757,9 @@ class ImageGenerators(MixinMeta):
                         centering=(0.5, 0.5),
                     )
                     temp = output
-                    output = output.resize((size - total_gap, size - total_gap), Image.ANTIALIAS)
+                    output = output.resize((size - total_gap, size - total_gap), LANCZOS)
                     temp.close()
-                    inner_mask = mask.resize((size - total_gap, size - total_gap), Image.ANTIALIAS)
+                    inner_mask = mask.resize((size - total_gap, size - total_gap), LANCZOS)
                     process.paste(
                         output,
                         (coord[0] + border_width, coord[1] + border_width),
@@ -771,9 +775,9 @@ class ImageGenerators(MixinMeta):
                         centering=(0.5, 0.5),
                     )
                     temp = output
-                    output = output.resize((size, size), Image.ANTIALIAS)
+                    output = output.resize((size, size), LANCZOS)
                     temp.close()
-                    outer_mask = mask.resize((size, size), Image.ANTIALIAS)
+                    outer_mask = mask.resize((size, size), LANCZOS)
                     process.paste(output, coord, outer_mask)
                     outer_mask.close()
                 badge_image_resized.close()
@@ -808,9 +812,9 @@ class ImageGenerators(MixinMeta):
                 # put border on ellipse/circle
                 output = ImageOps.fit(plus_square, (raw_length, raw_length), centering=(0.5, 0.5))
                 temp = output
-                output = output.resize((size, size), Image.ANTIALIAS)
+                output = output.resize((size, size), LANCZOS)
                 temp.close()
-                outer_mask = mask.resize((size, size), Image.ANTIALIAS)
+                outer_mask = mask.resize((size, size), LANCZOS)
                 process.paste(output, coord, outer_mask)
                 outer_mask.close()
                 plus_square.close()

--- a/leveler/image_generators.py
+++ b/leveler/image_generators.py
@@ -689,11 +689,11 @@ class ImageGenerators(MixinMeta):
             offset = 195
         margin = 140
         txt_color = self._contrast(info_fill, white_color, dark_color)
-        for line in textwrap.wrap(userinfo["info"], width=32):
+        for line in textwrap.wrap(userinfo["info"], width=27):
             # for line in textwrap.wrap('userinfo["info"]', width=200):
             # draw.text((margin, offset), line, font=text_fnt, fill=white_color)
             _write_unicode(line, margin, offset, text_fnt, text_u_fnt, txt_color)
-            offset += self._write_getsize_position_line(text_fnt, line) + 2
+            offset += 18
 
         # if await self.config.badge_type() == "circles":
         # circles require antialiasing

--- a/leveler/image_generators.py
+++ b/leveler/image_generators.py
@@ -81,10 +81,10 @@ class ImageGenerators(MixinMeta):
                 # if char.isalnum() or char in string.punctuation or char in string.whitespace:
                 if self.char_in_font(char, check_font):
                     draw.text((write_pos, y), "{}".format(char), font=font, fill=fill)
-                    write_pos += int(font.getlength(char))
+                    write_pos += self._write_getsize_position_character(font, char)
                 else:
                     draw.text((write_pos, y), "{}".format(char), font=unicode_font, fill=fill)
-                    write_pos += int(unicode_font.getlength(char))
+                    write_pos += self._write_getsize_position_character(unicode_font, char)
             check_font.close()
 
         # set canvas
@@ -454,10 +454,10 @@ class ImageGenerators(MixinMeta):
                 # if char.isalnum() or char in string.punctuation or char in string.whitespace:
                 if self.char_in_font(char, check_font):
                     draw.text((write_pos, y), "{}".format(char), font=font, fill=fill)
-                    write_pos += int(font.getlength(char))
+                    write_pos += self._write_getsize_position_character(font, char)
                 else:
                     draw.text((write_pos, y), "{}".format(char), font=unicode_font, fill=fill)
-                    write_pos += int(unicode_font.getlength(char))
+                    write_pos += self._write_getsize_position_character(unicode_font, char)
             check_font.close()
 
         # COLORS
@@ -693,7 +693,7 @@ class ImageGenerators(MixinMeta):
             # for line in textwrap.wrap('userinfo["info"]', width=200):
             # draw.text((margin, offset), line, font=text_fnt, fill=white_color)
             _write_unicode(line, margin, offset, text_fnt, text_u_fnt, txt_color)
-            offset += text_fnt.getbbox(line)[3] + 2
+            offset += self._write_getsize_position_line(text_fnt, line) + 2
 
         # if await self.config.badge_type() == "circles":
         # circles require antialiasing

--- a/leveler/image_generators.py
+++ b/leveler/image_generators.py
@@ -22,6 +22,7 @@ except Exception as e:
         "https://github.com/fixator10/Fixator10-Cogs/wiki/"
         "Installing-Leveler#my-bot-throws-error-on-load-something-related-to-pillow."
     )
+
 try:
     from PIL.Image.Resampling import LANCZOS
 except ModuleNotFoundError:

--- a/leveler/image_generators.py
+++ b/leveler/image_generators.py
@@ -81,10 +81,10 @@ class ImageGenerators(MixinMeta):
                 # if char.isalnum() or char in string.punctuation or char in string.whitespace:
                 if self.char_in_font(char, check_font):
                     draw.text((write_pos, y), "{}".format(char), font=font, fill=fill)
-                    write_pos += self._write_getsize_position_character(font, char)
+                    write_pos += self._get_character_pixel_width(font, char)
                 else:
                     draw.text((write_pos, y), "{}".format(char), font=unicode_font, fill=fill)
-                    write_pos += self._write_getsize_position_character(unicode_font, char)
+                    write_pos += self._get_character_pixel_width(unicode_font, char)
             check_font.close()
 
         # set canvas
@@ -454,10 +454,10 @@ class ImageGenerators(MixinMeta):
                 # if char.isalnum() or char in string.punctuation or char in string.whitespace:
                 if self.char_in_font(char, check_font):
                     draw.text((write_pos, y), "{}".format(char), font=font, fill=fill)
-                    write_pos += self._write_getsize_position_character(font, char)
+                    write_pos += self._get_character_pixel_width(font, char)
                 else:
                     draw.text((write_pos, y), "{}".format(char), font=unicode_font, fill=fill)
-                    write_pos += self._write_getsize_position_character(unicode_font, char)
+                    write_pos += self._get_character_pixel_width(unicode_font, char)
             check_font.close()
 
         # COLORS

--- a/leveler/image_generators.py
+++ b/leveler/image_generators.py
@@ -81,10 +81,10 @@ class ImageGenerators(MixinMeta):
                 # if char.isalnum() or char in string.punctuation or char in string.whitespace:
                 if self.char_in_font(char, check_font):
                     draw.text((write_pos, y), "{}".format(char), font=font, fill=fill)
-                    write_pos += font.getlength(char)[0]
+                    write_pos += int(font.getlength(char))
                 else:
                     draw.text((write_pos, y), "{}".format(char), font=unicode_font, fill=fill)
-                    write_pos += unicode_font.getlength(char)[0]
+                    write_pos += int(unicode_font.getlength(char))
             check_font.close()
 
         # set canvas
@@ -454,10 +454,10 @@ class ImageGenerators(MixinMeta):
                 # if char.isalnum() or char in string.punctuation or char in string.whitespace:
                 if self.char_in_font(char, check_font):
                     draw.text((write_pos, y), "{}".format(char), font=font, fill=fill)
-                    write_pos += font.getlength(char)[0]
+                    write_pos += int(font.getlength(char))
                 else:
                     draw.text((write_pos, y), "{}".format(char), font=unicode_font, fill=fill)
-                    write_pos += unicode_font.getlength(char)[0]
+                    write_pos += int(unicode_font.getlength(char))
             check_font.close()
 
         # COLORS
@@ -693,7 +693,7 @@ class ImageGenerators(MixinMeta):
             # for line in textwrap.wrap('userinfo["info"]', width=200):
             # draw.text((margin, offset), line, font=text_fnt, fill=white_color)
             _write_unicode(line, margin, offset, text_fnt, text_u_fnt, txt_color)
-            offset += text_fnt.getlength(line)[1] + 2
+            offset += text_fnt.getbbox(line)[3] + 2
 
         # if await self.config.badge_type() == "circles":
         # circles require antialiasing

--- a/leveler/leveler.py
+++ b/leveler/leveler.py
@@ -29,7 +29,7 @@ class Leveler(
 ):
     """A level up thing with image generation!"""
 
-    __version__ = "3.0.4"
+    __version__ = "3.0.5"
 
     # noinspection PyMissingConstructor
     def __init__(self, bot: Red):

--- a/leveler/leveler.py
+++ b/leveler/leveler.py
@@ -29,7 +29,7 @@ class Leveler(
 ):
     """A level up thing with image generation!"""
 
-    __version__ = "3.0.3"
+    __version__ = "3.0.4"
 
     # noinspection PyMissingConstructor
     def __init__(self, bot: Red):

--- a/leveler/utils.py
+++ b/leveler/utils.py
@@ -116,8 +116,6 @@ class Utils(MixinMeta):
 
         Single characters should use _write_getsize_position_character instead of this function.
         """
-        print(type(line))
-        print(line)
         try:
             write_pos = font.getbbox(line)[3]
         except AttributeError:

--- a/leveler/utils.py
+++ b/leveler/utils.py
@@ -96,13 +96,8 @@ class Utils(MixinMeta):
         return text
 
     @staticmethod
-    def _write_getsize_position_character(font: ImageFont.FreeTypeFont, char: str) -> int:
-        """
-        Use getlength over using getsize for characters, if available in PIL.
-
-        Lines of characters (more than 1 character) should use _write_getsize_position_line
-        instead of this function.
-        """
+    def _get_character_pixel_width(font: ImageFont.FreeTypeFont, char: str) -> int:
+        """Use getlength over using getsize for character pixel width, if available in PIL."""
         try:
             write_pos = int(font.getlength(char))
         except AttributeError:

--- a/leveler/utils.py
+++ b/leveler/utils.py
@@ -108,16 +108,3 @@ class Utils(MixinMeta):
         except AttributeError:
             write_pos = font.getsize(char)[0]
         return write_pos
-
-    @staticmethod
-    def _write_getsize_position_line(font: ImageFont.FreeTypeFont, line: str) -> int:
-        """
-        Use getbbox over using getsize for positions of lines of characters, if available in PIL.
-
-        Single characters should use _write_getsize_position_character instead of this function.
-        """
-        try:
-            write_pos = font.getbbox(line)[3]
-        except AttributeError:
-            write_pos = font.getsize(line)[1]
-        return write_pos

--- a/leveler/utils.py
+++ b/leveler/utils.py
@@ -9,6 +9,16 @@ from redbot.core.utils.predicates import MessagePredicate
 
 from .abc import MixinMeta
 
+try:
+    from PIL import ImageFont
+except Exception as e:
+    raise CogLoadError(
+        f"Can't load pillow: {e}\n"
+        "Please follow next steps on wiki: "
+        "https://github.com/fixator10/Fixator10-Cogs/wiki/"
+        "Installing-Leveler#my-bot-throws-error-on-load-something-related-to-pillow."
+    )
+
 
 class Utils(MixinMeta):
     """Utility methods"""
@@ -84,3 +94,32 @@ class Utils(MixinMeta):
         if len(text) > max_length:
             return text[: max_length - 1] + "…"
         return text
+
+    @staticmethod
+    def _write_getsize_position_character(font: ImageFont.FreeTypeFont, char: str) -> int:
+        """
+        Use getlength over using getsize for characters, if available in PIL.
+
+        Lines of characters (more than 1 character) should use _write_getsize_position_line
+        instead of this function.
+        """
+        try:
+            write_pos = int(font.getlength(char))
+        except AttributeError:
+            write_pos = font.getsize(char)[0]
+        return write_pos
+
+    @staticmethod
+    def _write_getsize_position_line(font: ImageFont.FreeTypeFont, line: str) -> int:
+        """
+        Use getbbox over using getsize for positions of lines of characters, if available in PIL.
+
+        Single characters should use _write_getsize_position_character instead of this function.
+        """
+        print(type(line))
+        print(line)
+        try:
+            write_pos = font.getbbox(line)[3]
+        except AttributeError:
+            write_pos = font.getsize(line)[1]
+        return write_pos


### PR DESCRIPTION
In Pillow 9.2+ there are dep warnings warning against the use of getsize and Image.ANTIALIAS. This PR resolves these issues and uses the functions that are suggested instead. getsize and Image.ANTIALIAS will be removed in Pillow version 10.

This PR was tested on a bot running Pillow 9.2.0 and a bot running Pillow 7.1.1.

For text like the user name and the user title, it was previously using getsize[0] where it seems like int(getlength) would be very comparable to the getsize values. It is a slightly different number in some cases, but I feel the overall output has better font kerning by using getlength. I have only tested this with latin characters, but the font used for the username and title does not support non-latin characters anyway...

```
text: AIKATERNA
char: A
getsize: (21, 23)
getlength: 19.0
getbbox: (-1, 1, 20, 23)
-----------------
text: AIKATERNA
char: I
getsize: (9, 23)
getlength: 9.0
getbbox: (0, 1, 9, 23)
-----------------
text: AIKATERNA
char: K
getsize: (20, 23)
getlength: 20.0
getbbox: (0, 1, 20, 23)
-----------------
text: AIKATERNA
char: A
getsize: (21, 23)
getlength: 19.0
getbbox: (-1, 1, 20, 23)
-----------------
text: AIKATERNA
char: T
getsize: (19, 23)
getlength: 19.0
getbbox: (0, 1, 19, 23)
-----------------
text: AIKATERNA
char: E
getsize: (18, 23)
getlength: 18.0
getbbox: (0, 1, 18, 23)
-----------------
text: AIKATERNA
char: R
getsize: (21, 23)
getlength: 20.0
getbbox: (0, 1, 21, 23)
-----------------
text: AIKATERNA
char: N
getsize: (21, 23)
getlength: 21.0
getbbox: (0, 1, 21, 23)
-----------------
text: AIKATERNA
char: A
getsize: (21, 23)
getlength: 19.0
getbbox: (-1, 1, 20, 23)
```

For text lines like the info box, getsize[1] was used previously, which seems to be equivalent to getbbox[3]:
```
char: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
getsize: (224, 14)
getlength: 224.0
getbbox: (0, 7, 224, 14)
-----------------
char: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
getsize: (224, 14)
getlength: 224.0
getbbox: (0, 7, 224, 14)
-----------------
char: aaaaaaaaaaaaaaaaaaaaaaaaaa
getsize: (182, 14)
getlength: 182.0
getbbox: (0, 7, 182, 14)
-----------------
```