### PR TITLE
[Leveler] Adjust vertical text line placement and info box width

### DIFF
--- a/leveler/image_generators.py
+++ b/leveler/image_generators.py
@@ -684,11 +684,11 @@ class ImageGenerators(MixinMeta):
             offset = 195
         margin = 140
         txt_color = self._contrast(info_fill, white_color, dark_color)
-        for line in textwrap.wrap(userinfo["info"], width=32):
+        for line in textwrap.wrap(userinfo["info"], width=27):
             # for line in textwrap.wrap('userinfo["info"]', width=200):
             # draw.text((margin, offset), line, font=text_fnt, fill=white_color)
             _write_unicode(line, margin, offset, text_fnt, text_u_fnt, txt_color)
-            offset += text_fnt.getsize(line)[1] + 2
+            offset += 18
 
         # if await self.config.badge_type() == "circles":
         # circles require antialiasing

--- a/leveler/leveler.py
+++ b/leveler/leveler.py
@@ -29,7 +29,7 @@ class Leveler(
 ):
     """A level up thing with image generation!"""
 
-    __version__ = "3.0.3"
+    __version__ = "3.0.4"
 
     # noinspection PyMissingConstructor
     def __init__(self, bot: Red):


### PR DESCRIPTION
This PR adjusts the width of the info box so that text does not run off the edge of the profile. This PR also replaces a placement function with a more definite number. Currently each line of the info is placed on the profile arbitrarily, where a y (vertical placement) position is found through text size. I found that on existing code, this could have differences in the pixel height placement. 

For example, on a test user that had info that was 150 chars long, the y value for the lines was as follows:
195 (initial y defined in the profile function)
214 (+19)
234 (+20)
253 (+19)
270 (+17)
290 (+20)
Which ends up looking visually uneven, like the vertical positioning on this profile for the info text - the "incididunt" line is rather close to the "dolore" line:
![profile-2](https://user-images.githubusercontent.com/20862007/184511576-4593c256-dc9a-4552-b317-98d4eb15d10c.png)
After setting the offset manually to always be 18px, the info text looks a lot more even:
![profile-3](https://user-images.githubusercontent.com/20862007/184511597-4430dc52-cef1-407c-b0ad-44df50a835ee.png)
Note that this info text is the max length currently allowed (150 characters), so info should not be longer than this example.

Shortening the info box width is also showcased here:
![profile-4](https://user-images.githubusercontent.com/20862007/184511611-83f290db-4849-4faf-99a4-ca7718082d47.png)

**Note that this PR conflicts slightly with** https://github.com/fixator10/Fixator10-Cogs/pull/177 **in the idea that I added** `_write_getsize_position_line` **use where in this PR it would be removed/unused because there is not a need for a y (horizontal) text line placement function after this change.** 