### PR TITLE
[Leveler] Fix dep warnings, part 2

### DIFF
--- a/leveler/def_imgen_utils.py
+++ b/leveler/def_imgen_utils.py
@@ -20,7 +20,8 @@ except Exception as e:
     )
 
 try:
-    from PIL.Image.Resampling import LANCZOS
+    from PIL import Image
+    LANCZOS = Image.Resampling.LANCZOS
 except ModuleNotFoundError:
     from PIL.Image import LANCZOS
 

--- a/leveler/def_imgen_utils.py
+++ b/leveler/def_imgen_utils.py
@@ -21,6 +21,7 @@ except Exception as e:
 
 try:
     from PIL import Image
+
     LANCZOS = Image.Resampling.LANCZOS
 except ModuleNotFoundError:
     from PIL.Image import LANCZOS

--- a/leveler/image_generators.py
+++ b/leveler/image_generators.py
@@ -24,7 +24,8 @@ except Exception as e:
     )
 
 try:
-    from PIL.Image.Resampling import LANCZOS
+    from PIL import Image
+    LANCZOS = Image.Resampling.LANCZOS
 except ModuleNotFoundError:
     from PIL.Image import LANCZOS
 

--- a/leveler/image_generators.py
+++ b/leveler/image_generators.py
@@ -25,6 +25,7 @@ except Exception as e:
 
 try:
     from PIL import Image
+
     LANCZOS = Image.Resampling.LANCZOS
 except ModuleNotFoundError:
     from PIL.Image import LANCZOS

--- a/leveler/leveler.py
+++ b/leveler/leveler.py
@@ -29,7 +29,7 @@ class Leveler(
 ):
     """A level up thing with image generation!"""
 
-    __version__ = "3.0.5"
+    __version__ = "3.0.6"
 
     # noinspection PyMissingConstructor
     def __init__(self, bot: Red):


### PR DESCRIPTION
Sorry to say I didn't catch this the first time. `from PIL.Image.Resampling import LANCZOS` didn't work as I expected on Pillow 9.2+.