### PR TITLE
[Leveler] Fix for lvlset profile color default/reset

### DIFF
--- a/leveler/commands/lvlset/profile.py
+++ b/leveler/commands/lvlset/profile.py
@@ -25,7 +25,7 @@ class Profile(MixinMeta):
         """Set profile color.
 
         For section, you can choose: `exp`, `rep`, `badge`, `info` or `all`.
-        For color, you can use: `default`, `white`, `HEX code` (#000000) or `auto`.
+        For color, you can use: `reset`, `white`, `HEX code` (#000000) or `auto`.
         e.g: `[p]lvlset profile color all #eb4034`"""
         user = ctx.author
         userinfo = await self.db.users.find_one({"user_id": str(user.id)})
@@ -82,7 +82,7 @@ class Profile(MixinMeta):
                 set_color = [await self._hex_to_rgb(color, default_a) for color in hex_colors]
             else:
                 set_color = hex_colors[0]
-        elif color == "default":
+        elif color == "reset":
             if section == "exp":
                 set_color = default_exp
             elif section == "rep":
@@ -101,7 +101,12 @@ class Profile(MixinMeta):
         elif isinstance(color, discord.Color):
             set_color = (color.r, color.g, color.b, default_a)
         else:
-            await ctx.send("Not a valid color. Must be `default`, `HEX color` or `auto`.")
+            msg = (
+                "Not a valid color. "
+                "Must be a color name like `blurple`, a hex code formatted like `#000000`, "
+                "`auto` for auto-color or `reset` to reset to the default colors."
+            )
+            await ctx.send(msg)
             return
 
         if section == "all":
@@ -117,7 +122,7 @@ class Profile(MixinMeta):
                         }
                     },
                 )
-            elif color == "default":
+            elif color == "reset":
                 await self.db.users.update_one(
                     {"user_id": str(user.id)},
                     {

--- a/leveler/commands/lvlset/profile.py
+++ b/leveler/commands/lvlset/profile.py
@@ -25,7 +25,7 @@ class Profile(MixinMeta):
         """Set profile color.
 
         For section, you can choose: `exp`, `rep`, `badge`, `info` or `all`.
-        For color, you can use: 
+        For color, you can use:
         a color name like `blurple`, a hex code (`#000000`), `auto` for auto-color
         or reset the values to their defaults with `reset`.
         e.g: `[p]lvlset profile color all #eb4034`"""

--- a/leveler/commands/lvlset/profile.py
+++ b/leveler/commands/lvlset/profile.py
@@ -25,7 +25,9 @@ class Profile(MixinMeta):
         """Set profile color.
 
         For section, you can choose: `exp`, `rep`, `badge`, `info` or `all`.
-        For color, you can use: `reset`, `white`, `HEX code` (#000000) or `auto`.
+        For color, you can use: 
+        a color name like `blurple`, a hex code (`#000000`), `auto` for auto-color
+        or reset the values to their defaults with `reset`.
         e.g: `[p]lvlset profile color all #eb4034`"""
         user = ctx.author
         userinfo = await self.db.users.find_one({"user_id": str(user.id)})

--- a/leveler/leveler.py
+++ b/leveler/leveler.py
@@ -29,7 +29,7 @@ class Leveler(
 ):
     """A level up thing with image generation!"""
 
-    __version__ = "3.0.6"
+    __version__ = "3.0.7"
 
     # noinspection PyMissingConstructor
     def __init__(self, bot: Red):


### PR DESCRIPTION
By using a Union with discord.Color and str for the input on this command causes it to read the string "default" as a discord.Color with equal to #00000. This PR changes the word used on the user side from "default" to "reset" and I have also adjusted the text presented to the user on invalid input and also in the command help so that it is more clear.