### PR TITLE
Change `[p]thetime` it to a `timezone'd` time

### DIFF
--- a/moreutils/moreutils.py
+++ b/moreutils/moreutils.py
@@ -1,7 +1,7 @@
 ﻿import colorsys
 import datetime
-import random
 import math
+import random
 
 import aiohttp
 import discord

--- a/moreutils/moreutils.py
+++ b/moreutils/moreutils.py
@@ -1,6 +1,7 @@
 ﻿import colorsys
 import datetime
 import random
+import math
 
 import aiohttp
 import discord
@@ -113,8 +114,9 @@ class MoreUtils(commands.Cog):
 
     @commands.command(name="thetime")
     async def _thetime(self, ctx):
-        """Displays the current time of the server."""
-        await ctx.send(datetime.datetime.now().strftime(SM_DATETIME_FORMAT))
+        """Displays the current time."""
+        unix_timestamp = math.floor(datetime.datetime.timestamp(datetime.datetime.now()))
+        await ctx.send("<t:{}:f>".format(unix_timestamp))
 
     @commands.command(aliases=["HEX", "hex", "colour"])
     @commands.bot_has_permissions(embed_links=True)


### PR DESCRIPTION
Still Servers time, but now "timezone'd"

Reason why:  server for my bot is in Germany, but most of my guilds members are living in US.... so, why not "timezone" it?

Changes
from  
![image](https://i.imgur.com/nqjK5q7.png)
to
![image2](https://i.imgur.com/bitaahR.png)

( which does looks different if you're in another timezone )

took me 10 minutes to learn the line and another 5 "testing" 😏  


---

![fails](https://tenor.com/bt6Jo.gif)
![fail1](https://i.imgur.com/RnfxOpm.png)
![fail2](https://i.imgur.com/fEpr8SH.png)

`Edit: changed links to images`