### PR TITLE
add `use_external_apps` permission (1 << 50)

### DIFF
--- a/permissions-calculator/assets/js/permissions.js
+++ b/permissions-calculator/assets/js/permissions.js
@@ -167,6 +167,7 @@ angular.module('permissionsCalc', ['themes'])
                     { active: false, id: 'add_reactions',            name: 'Add Reactions',             value: 0x40,            auto: true  }, // 1 << 6
                     { active: false, id: 'use_application_commands', name: 'Use Application Commands',  value: 0x80000000,      auto: true  }, // 1 << 31
                     { active: false, id: 'send_polls',               name: 'Create Polls',              value: 0x2000000000000, auto: true  }, // 1 << 49
+                    { active: false, id: 'use_external_apps',        name: 'Use External Apps',         value: 0x4000000000000, auto: true  }, // 1 << 50
                 ]
             },
             {


### PR DESCRIPTION
Looks like Discord added yet another permission to moderate user apps: https://github.com/discord/discord-api-docs/pull/6913
and its in the client too.